### PR TITLE
Add all of the source layer to the research map

### DIFF
--- a/src/components/Filter.svelte
+++ b/src/components/Filter.svelte
@@ -97,7 +97,7 @@
   </Select>
 {/if}
 
-{#if selectedAttribute && selectedAttribute.dataType === "continuous"}
+{#if selectedAttribute && selectedAttribute.dataType === "numeric"}
   <Label for="value-select">Select a value</Label>
   <RangeSlider
     id="value-select"

--- a/src/components/nodes/DataSourceDrawer.svelte
+++ b/src/components/nodes/DataSourceDrawer.svelte
@@ -9,6 +9,7 @@
     Input,
     Textarea,
   } from "flowbite-svelte";
+  import { addNewMarkupNodeCollection } from "../../utils/addNewNodes.mjs";
   import { map } from "../Map.svelte";
 
   let handler, rows;
@@ -73,6 +74,17 @@
           }}
         >
           Remove Source</Button
+        >
+        <Button
+          size="xs"
+          class="px-1 py-0 m-0 rounded-sm"
+          on:click={() => {
+            addNewMarkupNodeCollection(
+              sourceNode.fileName,
+              sourceNode.layerName,
+              ["all", "any"]
+            );
+          }}>Add all to Research map</Button
         >
       </section>
       {#if sourceNode.attributes}

--- a/src/utils/mapMovements.mjs
+++ b/src/utils/mapMovements.mjs
@@ -8,7 +8,6 @@ export function zoomToFeature(feature, featureSource, map, type = "singular") {
     geometry = feature._geometry ? feature._geometry : feature.geometry;
   }
   if (type == "collection") {
-    console.log(featureSource);
     geometry = map.getSource(featureSource); //._data.features[0].geometry;
     let bbox = Turf.bbox(geometry._data);
     map.fitBounds(bbox);

--- a/src/utils/spatialRenderer.mjs
+++ b/src/utils/spatialRenderer.mjs
@@ -25,7 +25,7 @@ export async function loadSpatialData(
   try {
     map.addSource(fileName, {
       type: "geojson",
-      data: fileUrl,
+      data: responseData,
     });
   } catch (error) {
     alert(error);


### PR DESCRIPTION
## BugFixes:
- Feeding Maplibre data from URL means data is not contained in the internal ```getSource()```, this has been reverted to take data from Fetched data from the URL
## Feature
- There is now an option to add the complete layer to the research map